### PR TITLE
Change redirects to be portable

### DIFF
--- a/lib/multi_repo/service/docker.rb
+++ b/lib/multi_repo/service/docker.rb
@@ -17,7 +17,7 @@ module MultiRepo::Service
     def self.ensure_small_image
       return @has_small_image if defined?(@has_small_image)
 
-      return false unless system?("docker pull #{SMALL_IMAGE} &>/dev/null")
+      return false unless system?("docker pull #{SMALL_IMAGE} >/dev/null 2>&1")
 
       @has_small_image = true
     end

--- a/lib/multi_repo/service/git.rb
+++ b/lib/multi_repo/service/git.rb
@@ -24,7 +24,7 @@ module MultiRepo::Service
 
       args = ["clone", clone_source, path]
       command = Shellwords.join(["git", *args])
-      command << " &>/dev/null" unless ENV["GIT_DEBUG"]
+      command << " >/dev/null 2>&1" unless ENV["GIT_DEBUG"]
       puts "+ #{command}" if ENV["GIT_DEBUG"] # Matches the output of MiniGit
 
       raise MiniGit::GitError.new(args, $?) unless system(command)


### PR DESCRIPTION
Since the underlying shell used by system can be different, prefer a portable version of redirection as &> is shell specific

@agrare Please review.