### PR TITLE
Change git mirror to no longer rebase extra commits

### DIFF
--- a/lib/multi_repo/helpers/git_mirror.rb
+++ b/lib/multi_repo/helpers/git_mirror.rb
@@ -164,7 +164,7 @@ module MultiRepo::Helpers
 
       success =
         system("git checkout -B #{dest_name} #{start_point}") &&
-        system("git pull --rebase=merges #{source_remote} #{source_name}") &&
+        system("git pull --no-rebase #{source_remote} #{source_name}") &&
         system("git push -f #{dest_remote} #{dest_name}")
 
       if backup_remote_defined?


### PR DESCRIPTION
Given mirrored_master is the downstream mirror of upstream's master:

I tested
- [x] when mirrored_master matches upstream/master

```
# Before & After
*   7fd1a60 - (HEAD -> mirrored_master, upstream/master, upstream/HEAD, downstream/mirrored_master, downstream/master, master) Merge pull request #6 from Spaceghost/patch-1 (11 years ago) <The Octocat>
|\
| * 7629413 - New line at end of file. --Signed off by Spaceghost (12 years ago) <Johnneylee Jack Rollins>
|/
* 553c207 - first commit (12 years ago) <cameronmcefee>
```

- [x]  when mirrored_master is behind upstream/master

```
# Before
*   7fd1a60 - (upstream/master, upstream/HEAD, downstream/master, master) Merge pull request #6 from Spaceghost/patch-1 (11 years ago) <The Octocat>
|\
| * 7629413 - New line at end of file. --Signed off by Spaceghost (12 years ago) <Johnneylee Jack Rollins>
|/
* 553c207 - (HEAD -> mirrored_master, downstream/mirrored_master) first commit (12 years ago) <cameronmcefee>

# After (moves to match master)
*   7fd1a60 - (HEAD -> mirrored_master, upstream/master, upstream/HEAD, downstream/mirrored_master, downstream/master, master) Merge pull request #6 from Spaceghost/patch-1 (11 years ago) <The Octocat>
|\
| * 7629413 - New line at end of file. --Signed off by Spaceghost (12 years ago) <Johnneylee Jack Rollins>
|/
* 553c207 - first commit (12 years ago) <cameronmcefee>
```

- [x] when mirrored_master is a commit ahead of upstream/master

```
# Before & After
* 5e48563 - (HEAD -> mirrored_master, downstream/mirrored_master) Commit ahead of upstream/master (18 seconds ago) <Jason Frey>
*   7fd1a60 - (upstream/master, upstream/HEAD, downstream/master, master) Merge pull request #6 from Spaceghost/patch-1 (11 years ago) <The Octocat>
|\
| * 7629413 - New line at end of file. --Signed off by Spaceghost (12 years ago) <Johnneylee Jack Rollins>
|/
* 553c207 - first commit (12 years ago) <cameronmcefee>
```

- [x] when mirrored_master has an extra commit and is behind upstream/master (this is the case being changed - formerly this would rebase on top of upstream/master creating a new commit)

```
# Before
* 255c493 - (HEAD -> mirrored_master, downstream/mirrored_master) Commit behind upstream/master (24 seconds ago) <Jason Frey>
| * 7fd1a60 - (upstream/master, upstream/HEAD, downstream/master, master) Merge pull request #6 from Spaceghost/patch-1 (11 years ago) <The Octocat>
|/|
| * 7629413 - New line at end of file. --Signed off by Spaceghost (12 years ago) <Johnneylee Jack Rollins>
|/
* 553c207 - first commit (12 years ago) <cameronmcefee>

# After (& again running a second time)
*   897c65d - (HEAD -> mirrored_master, downstream/mirrored_master) Merge branch 'master' of github.com:octocat/Hello-World into mirrored_master (6 seconds ago) <Jason Frey>
|\
| *   7fd1a60 - (upstream/master, upstream/HEAD, downstream/master, master) Merge pull request #6 from Spaceghost/patch-1 (11 years ago) <The Octocat>
| |\
| | * 7629413 - New line at end of file. --Signed off by Spaceghost (12 years ago) <Johnneylee Jack Rollins>
| |/
* / 255c493 - Commit behind upstream/master (73 seconds ago) <Jason Frey>
|/
* 553c207 - first commit (12 years ago) <cameronmcefee>
```

- [x] when mirrored_master has a merge commit pattern and is behind upstream/master (similar case to the previous, but with a merge commit as opposed to a single bare commit)

```
# Before 
*   978a052 - (HEAD -> mirrored_master, downstream/mirrored_master) Merge commit '255c493' into mirrored_master (2 minutes ago) <Jason Frey>
|\
| * 255c493 - Commit behind upstream/master (7 minutes ago) <Jason Frey>
|/
| * 7fd1a60 - (upstream/master, upstream/HEAD, downstream/master, master) Merge pull request #6 from Spaceghost/patch-1 (11 years ago) <The Octocat>
|/|
| * 7629413 - New line at end of file. --Signed off by Spaceghost (12 years ago) <Johnneylee Jack Rollins>
|/
* 553c207 - first commit (12 years ago) <cameronmcefee>

# After (& again running a second time)
*   cfe11e0 - (HEAD -> mirrored_master, downstream/mirrored_master) Merge branch 'master' of github.com:octocat/Hello-World into mirrored_master (56 seconds ago) <Jason Frey>
|\
| *   7fd1a60 - (upstream/master, upstream/HEAD, downstream/master, master) Merge pull request #6 from Spaceghost/patch-1 (11 years ago) <The Octocat>
| |\
| | * 7629413 - New line at end of file. --Signed off by Spaceghost (12 years ago) <Johnneylee Jack Rollins>
| |/
* |   978a052 - Merge commit '255c493' into mirrored_master (3 minutes ago) <Jason Frey>
|\ \
| |/
|/|
| * 255c493 - Commit behind upstream/master (8 minutes ago) <Jason Frey>
|/
* 553c207 - first commit (12 years ago) <cameronmcefee>
```

@bdunne Please review.  Please let me know if there are other cases you want me to verify.