### PR TITLE
Fix issue where newer versions of dry-configurable do not work on Ruby 2.7

### DIFF
--- a/multi_repo.gemspec
+++ b/multi_repo.gemspec
@@ -36,6 +36,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rest-client"
   spec.add_runtime_dependency "travis"
 
+  # config gem brings in newer versions of dry-configurable that are not compatible with Ruby 2.7
+  spec.add_runtime_dependency "dry-configurable", "= 1.0.1"
+
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
@bdunne Please review.