### PR TITLE
Add a synopsis to all scripts and show it in multi_repo help

### DIFF
--- a/exe/multi_repo
+++ b/exe/multi_repo
@@ -2,16 +2,26 @@
 
 SCRIPT_DIR = File.expand_path("../scripts", __dir__)
 
+def available_scripts
+  @available_scripts ||= Dir.children(SCRIPT_DIR).sort.to_h do |script|
+    desc = File.read(File.join(SCRIPT_DIR, script)).match(/synopsis(?:\(|\s+)['"](.*)['"]/)&.captures&.first
+    [script, desc]
+  end
+end
+
 def usage
   puts "Usage: multi_repo <script> [args]"
   puts "  script      Script to run"
   puts "  args        Arguments to pass to the script"
   puts "  -h, --help  Show this help message"
-
-  available_scripts = Dir.children(SCRIPT_DIR).sort.map { |f| "  #{f}"}
+  puts
+  puts "For help on a specific script, run:"
+  puts "  multi_repo <script> --help"
   puts
   puts "Available scripts:"
-  puts available_scripts
+
+  justify = available_scripts.keys.map(&:length).max + 2
+  puts available_scripts.map { |script, desc| "  #{script.ljust(justify)} #{desc}" }.join("\n")
 end
 
 script, args = ARGV[0], ARGV[1..]

--- a/scripts/delete_labels
+++ b/scripts/delete_labels
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Delete labels on all GitHub repos."
+
   opt :labels, "The labels to delete.", :type => :strings, :required => true
 
   MultiRepo::CLI.common_options(self, :repo_set_default => nil)

--- a/scripts/destroy_branch
+++ b/scripts/destroy_branch
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Destroy a branch on all local git repos."
+
   opt :branch, "The branch to destroy.", :type => :string, :required => true
 
   MultiRepo::CLI.common_options(self, :except => :dry_run)

--- a/scripts/destroy_remote
+++ b/scripts/destroy_remote
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Destroy a remote on all local git repos."
+
   opt :remote, "The remote to destroy", :type => :string, :required => true
 
   MultiRepo::CLI.common_options(self)

--- a/scripts/destroy_tag
+++ b/scripts/destroy_tag
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Destroy a tag on all local git repos."
+
   opt :tag, "The tag to destroy", :type => :string, :required => true
 
   MultiRepo::CLI.common_options(self, :except => :dry_run)

--- a/scripts/each_repo
+++ b/scripts/each_repo
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Run a command in each repo."
+
   opt :command, "A command to run in each repo", :type => :string, :required => true
   opt :ref, "Ref to checkout before running the command", :type => :string, :default => "master"
 

--- a/scripts/fetch_repos
+++ b/scripts/fetch_repos
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Fetch all repos."
+
   opt :checkout, "Branch to checkout after fetching.", :type => :string
 
   MultiRepo::CLI.common_options(self, :except => :dry_run)

--- a/scripts/git_mirror
+++ b/scripts/git_mirror
@@ -6,4 +6,8 @@ gemfile do
   gem "multi_repo", require: "multi_repo/cli", path: File.expand_path("..", __dir__)
 end
 
+Optimist.options do
+  synopsis "Mirror all GitHub repos into another org."
+end
+
 exit 1 unless MultiRepo::Helpers::GitMirror.new.mirror_all

--- a/scripts/github_rate_limit
+++ b/scripts/github_rate_limit
@@ -7,4 +7,8 @@ gemfile do
 end
 require "more_core_extensions/core_ext/array/tableize"
 
+Optimist.options do
+  synopsis "Display the current GitHub rate limit."
+end
+
 puts [MultiRepo::Service::Github.client.rate_limit.to_h].tableize

--- a/scripts/hacktoberfest
+++ b/scripts/hacktoberfest
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Apply the 'hacktoberfest' label to all 'good first issue' labels."
+
   opt :org,   "The organization to apply the `hacktoberfest` label to", :type => :string, :required => true
   opt :apply, "Apply the `hacktoberfest` label to `good first issue` labels. "\
               "Pass --no-apply to remove the `hacktoberfest` label",

--- a/scripts/make_alumni
+++ b/scripts/make_alumni
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Move a set of GitHub team members to an 'alumni' team."
+
   opt :users, "The users to make alumni.",     :type => :strings, :required => true
   opt :org,   "The org in which user belongs", :type => :string,  :required => true
 

--- a/scripts/new_rubygems_stub
+++ b/scripts/new_rubygems_stub
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Create a stub for a new Ruby gem on rubygems.org."
+
   opt :owners, "Owners to add to the gem stub", :type => :strings, :default => []
 
   MultiRepo::CLI.common_options(self, :except => :repo_set)

--- a/scripts/pull_request_blaster_outer
+++ b/scripts/pull_request_blaster_outer
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Create a pull request on all repos."
+
   opt :base,    "The target branch for the changes.",                         :type => :string, :required => true
   opt :head,    "The name of the branch to create on your fork.",             :type => :string, :required => true
   opt :script,  "The path to the script that will update the desired files.", :type => :string, :required => true

--- a/scripts/pull_request_labeler
+++ b/scripts/pull_request_labeler
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Add or remove labels on a set of pull requests."
+
   opt :prs,    "The list of PRs to merge", :type => :strings, :required => true
   opt :add,    "Labels to add",            :type => :strings, :required => true
   opt :remove, "Labels to remove",         :type => :strings, :required => true

--- a/scripts/pull_request_merger
+++ b/scripts/pull_request_merger
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Merge a set of pull requests, also setting assignee and labels."
+
   opt :prs,      "The list of PRs to merge",           :type => :strings, :required => true
   opt :assignee, "GitHub user to assign when merging", :type => :string,  :required => true
   opt :labels,   "Labels to apply when merging",       :type => :strings

--- a/scripts/reenable_repo_workflows
+++ b/scripts/reenable_repo_workflows
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Reenable all disabled workflows in an org."
+
   opt :org, "The organization to reenable workflows in", :type => :string, :required => true
   opt :extra_repos, "Extra repos to reenable workflows in", :type => :strings, :default => []
 

--- a/scripts/rename_labels
+++ b/scripts/rename_labels
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Rename labels on all GitHub repos."
+
   opt :old, "The old label names.", :type => :strings, :required => true
   opt :new, "The new label names.", :type => :strings, :required => true
 

--- a/scripts/restart_travis_builds
+++ b/scripts/restart_travis_builds
@@ -9,6 +9,8 @@ require 'travis'
 require 'travis/pro/auto_login'
 
 opts = Optimist.options do
+  synopsis "Restart all Travis builds for a given branch or tag for all GitHub repos."
+
   opt :ref, "The branch or release tag to rebuild.", :type => :string, :required => true
 
   MultiRepo::CLI.common_options(self, :except => :dry_run, :repo_set_default => nil)

--- a/scripts/show_commit_history
+++ b/scripts/show_commit_history
@@ -11,6 +11,8 @@ require "active_support/core_ext/string/inflections"
 DISPLAY_FORMATS = %w[commit pr-title pr-label]
 
 opts = Optimist.options do
+  synopsis "Show the git commit log between two refs for all git repos."
+
   opt :from,    "The commit log 'from' ref", :type => :string,  :required => true
   opt :to,      "The commit log 'to' ref" ,  :type => :string,  :required => true
   opt :display, "How to display the history. Valid values are: #{DISPLAY_FORMATS.join(", ")}", :default => "commit"

--- a/scripts/show_org_members
+++ b/scripts/show_org_members
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Show all members of an org."
+
   opt :org,    "The org to list the users for",    :type => :string, :required => true
   opt :team,   "Show members of a specific team",  :type => :string
   opt :alumni, "Whether or not to include alumni", :default => false

--- a/scripts/show_org_repos
+++ b/scripts/show_org_repos
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "List all repos in an org."
+
   opt :org, "The org to list the repos for", :type => :string, :required => true
 end
 

--- a/scripts/show_org_stats
+++ b/scripts/show_org_stats
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Show commit and merge stats for all git repos."
+
   opt :since, "Since what date.", :type => :string, :required => true
 
   MultiRepo::CLI.common_options(self, :except => :dry_run)

--- a/scripts/show_project_cards
+++ b/scripts/show_project_cards
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Show all issues in a GitHub project column."
+
   opt :project_id, "The project ID",                :type => :integer, :required => true
   opt :column,     "The column within the project", :type => :string,  :required => true
 

--- a/scripts/show_repo_set
+++ b/scripts/show_repo_set
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "List all repos in a repo set."
+
   MultiRepo::CLI.common_options(self, :only => :repo_set)
 end
 

--- a/scripts/show_tag
+++ b/scripts/show_tag
@@ -8,6 +8,8 @@ end
 require 'more_core_extensions/core_ext/array/tableize'
 
 opts = Optimist.options do
+  synopsis "Show the commit for a tag in all git repos."
+
   opt :tag, "The tag name.", :type => :string, :required => true
 
   MultiRepo::CLI.common_options(self, :except => :dry_run, :repo_set_default => nil)

--- a/scripts/show_travis_status
+++ b/scripts/show_travis_status
@@ -13,6 +13,8 @@ require 'travis'
 require 'travis/pro/auto_login'
 
 opts = Optimist.options do
+  synopsis "Show the Travis status for a branch or tag for all GitHub repos."
+
   opt :ref, "The branch or release tag to check status for.", :type => :string, :required => true
 
   MultiRepo::CLI.common_options(self, :except => :dry_run, :repo_set_default => nil)

--- a/scripts/update_branch_protection
+++ b/scripts/update_branch_protection
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Update the branch protection for all GitHub repos."
+
   opt :branch, "The branch to protect.", :type => :string, :required => true
 
   MultiRepo::CLI.common_options(self, :repo_set_default => nil)

--- a/scripts/update_labels
+++ b/scripts/update_labels
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Create or update labels on all GitHub repos."
+
   MultiRepo::CLI.common_options(self, :repo_set_default => nil)
 end
 opts[:repo] = MultiRepo::Labels.all.keys.sort unless opts[:repo] || opts[:repo_set]

--- a/scripts/update_milestone
+++ b/scripts/update_milestone
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Create, update, or close a milestone in all GitHub repos."
+
   opt :title,  "The milestone title.",            :type => :string, :required => true
   opt :due_on, "The due date.",                   :type => :string
   opt :close,  "Whether to close the milestone.", :default => false

--- a/scripts/update_repo_settings
+++ b/scripts/update_repo_settings
@@ -7,6 +7,8 @@ gemfile do
 end
 
 opts = Optimist.options do
+  synopsis "Update repo settings in all GitHub repos."
+
   MultiRepo::CLI.common_options(self)
 end
 


### PR DESCRIPTION
@bdunne Please review.

The help command now shows this:

```
$ multi_repo --help
Usage: multi_repo <script> [args]
  script      Script to run
  args        Arguments to pass to the script
  -h, --help  Show this help message

For help on a specific script, run:
  multi_repo <script> --help

Available scripts:
  delete_labels                Delete labels on all GitHub repos.
  destroy_branch               Destroy a branch on all local git repos.
  destroy_remote               Destroy a remote on all local git repos.
  destroy_tag                  Destroy a tag on all local git repos.
  each_repo                    Run a command in each repo.
  fetch_repos                  Fetch all repos.
  git_mirror                   Mirror all GitHub repos into another org.
  github_rate_limit            Display the current GitHub rate limit.
  hacktoberfest                Apply the 'hacktoberfest' label to all 'good first issue' labels.
  make_alumni                  Move a set of GitHub team members to an 'alumni' team.
  new_rubygems_stub            Create a stub for a new Ruby gem on rubygems.org.
  pull_request_blaster_outer   Create a pull request on all repos.
  pull_request_labeler         Add or remove labels on a set of pull requests.
  pull_request_merger          Merge a set of pull requests, also setting assignee and labels.
  reenable_repo_workflows      Reenable all disabled workflows in an org.
  rename_labels                Rename labels on all GitHub repos.
  restart_travis_builds        Restart all Travis builds for a given branch or tag for all GitHub repos.
  show_commit_history          Show the git commit log between two refs for all git repos.
  show_org_members             Show all members of an org.
  show_org_repos               List all repos in an org.
  show_org_stats               Show commit and merge stats for all git repos.
  show_project_cards           Show all issues in a GitHub project column.
  show_repo_set                List all repos in a repo set.
  show_tag                     Show the commit for a tag in all git repos.
  show_travis_status           Show the Travis status for a branch or tag for all GitHub repos.
  update_branch_protection     Update the branch protection for all GitHub repos.
  update_labels                Create or update labels on all GitHub repos.
  update_milestone             Create, update, or close a milestone in all GitHub repos.
  update_repo_settings         Update repo settings in all GitHub repos.
```