### PR TITLE
Drop Ruby 2.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.7'
         - '3.0'
+        - '3.1'
     env:
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
     steps:
@@ -27,6 +27,6 @@ jobs:
     - name: Run tests
       run: bundle exec rake
     - name: Report code coverage
-      if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.0' }}
+      if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.1' }}
       continue-on-error: true
       uses: paambaati/codeclimate-action@v5

--- a/multi_repo.gemspec
+++ b/multi_repo.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "colorize"
@@ -35,9 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rbnacl"
   spec.add_runtime_dependency "rest-client"
   spec.add_runtime_dependency "travis"
-
-  # config gem brings in newer versions of dry-configurable that are not compatible with Ruby 2.7
-  spec.add_runtime_dependency "dry-configurable", "= 1.0.1"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "manageiq-style"


### PR DESCRIPTION
Also add 3.1 to the test matrix

@bdunne Please review - Alternative to #14 

I will cut this as v0.3.0