### PR TITLE
Add missing require for fileutils

### DIFF
--- a/lib/multi_repo/helpers/git_mirror.rb
+++ b/lib/multi_repo/helpers/git_mirror.rb
@@ -3,6 +3,7 @@ module MultiRepo::Helpers
     def initialize
       require "colorize"
       require "config"
+      require "fileutils"
 
       @errors_occurred = false
     end


### PR DESCRIPTION
```
/home/jenkins/.local/share/gem/ruby/gems/multi_repo-0.2.2/lib/multi_repo/helpers/git_mirror.rb:88:in `with_repo': uninitialized constant MultiRepo::Helpers::GitMirror::FileUtils (NameError) Did you mean?  FileTest
	from /home/jenkins/.local/share/gem/ruby/gems/multi_repo-0.2.2/lib/multi_repo/helpers/git_mirror.rb:22:in `mirror'
	from /home/jenkins/.local/share/gem/ruby/gems/multi_repo-0.2.2/lib/multi_repo/helpers/git_mirror.rb:15:in `block in mirror_all'
	from /home/jenkins/.local/share/gem/ruby/gems/multi_repo-0.2.2/lib/multi_repo/helpers/git_mirror.rb:15:in `each'
	from /home/jenkins/.local/share/gem/ruby/gems/multi_repo-0.2.2/lib/multi_repo/helpers/git_mirror.rb:15:in `mirror_all'
	from /home/jenkins/.local/share/gem/ruby/gems/multi_repo-0.2.2/scripts/git_mirror:13:in `<main>'
```