### PR TITLE
[WIP] repo.name includes the user/repo so split to get just repo

### DIFF
--- a/lib/multi_repo/helpers/pull_request_blaster_outer.rb
+++ b/lib/multi_repo/helpers/pull_request_blaster_outer.rb
@@ -57,7 +57,7 @@ module MultiRepo::Helpers
     end
 
     def forked?
-      github.client.repos(github.client.login).any? { |m| m.name == repo.name }
+      github.client.repos(github.client.login).any? { |m| m.name.split("/").last == repo.name.split("/").last }
     end
 
     def fork_repo
@@ -104,7 +104,7 @@ module MultiRepo::Helpers
     end
 
     def origin_url
-      "git@github.com:#{github.client.login}/#{repo.name}.git"
+      "git@github.com:#{github.client.login}/#{repo.name.split("/").last}.git"
     end
 
     def pr_head


### PR DESCRIPTION
Note, I didn't yet look to see why this changed.  We might want to do this differently but this is what got it working locally for me.