### PR TITLE
Various updates to pr_blaster_outer

### DIFF
--- a/scripts/pull_request_blaster_outer
+++ b/scripts/pull_request_blaster_outer
@@ -4,7 +4,9 @@ require "bundler/inline"
 gemfile do
   source "https://rubygems.org"
   gem "multi_repo", require: "multi_repo/cli", path: File.expand_path("..", __dir__)
+  gem "more_core_extensions"
 end
+require "more_core_extensions/core_ext/array/tableize"
 
 opts = Optimist.options do
   synopsis "Create a pull request on all repos."
@@ -19,8 +21,11 @@ opts = Optimist.options do
 end
 
 results = {}
-MultiRepo::CLI.each_repo(**opts) do |repo|
-  results[repo.name] = MultiRepo::Helpers::PullRequestBlasterOuter.new(repo, **opts).blast
+begin
+  MultiRepo::CLI.each_repo(**opts) do |repo|
+    results[repo.name] = MultiRepo::Helpers::PullRequestBlasterOuter.new(repo, **opts).blast
+  end
+ensure
+  puts "Summary:"
+  puts results.to_a.tableize(:header => false) unless results.empty?
 end
-
-pp results


### PR DESCRIPTION
- Cleanup output with colors for consistency with other scripts.
- Dump the final output in tableized form with more helpful messages.
- Dump the final output even if the scripts fail so we don't lose the progress.
- Allow the run to continue if no changes are found. It's not uncommon for a script to only updates some repos, such as those bumping versions, but where the version is already updated externally.
- Run the script in an unbundled env to avoid bundler issues.
- Fix a few bugs around the multi_repo repo name being fully-qualified.

@jrafanie Please review.  I tried breaking this up into commits, but it was too hard.  These are various change I made to get the recent blast out working.

Example output showing some skipped repos where no changes happened, a repo where I chose to open the PR, and the summary updates:

![__dev_manageiq-release](https://github.com/ManageIQ/multi_repo/assets/52120/0636fee7-219d-49ad-ac0b-da4919a6bf95)
