### PR TITLE
Use newer method for actions-secrets creation

### DIFF
--- a/lib/multi_repo/service/github.rb
+++ b/lib/multi_repo/service/github.rb
@@ -212,17 +212,19 @@ module MultiRepo::Service
       payload = encode_secret(repo_name, value)
 
       if dry_run
-        puts "** dry-run: github.create_or_update_secret(#{repo_name.inspect}, #{key.inspect}, #{payload.inspect})".light_black
+        puts "** dry-run: github.create_or_update_actions_secret(#{repo_name.inspect}, #{key.inspect}, #{payload.inspect})".light_black
       else
-        client.create_or_update_secret(repo_name, key, payload)
+        client.create_or_update_actions_secret(repo_name, key, payload)
       end
     end
 
     private def encode_secret(repo_name, value)
+      raise ArgumentError, "value to encode cannot be nil" if value.nil?
+
       require "rbnacl"
       require "base64"
 
-      repo_public_key = client.get_public_key(repo_name)
+      repo_public_key = client.get_actions_public_key(repo_name)
       decoded_repo_public_key = Base64.decode64(repo_public_key.key)
       public_key = RbNaCl::PublicKey.new(decoded_repo_public_key)
       box = RbNaCl::Boxes::Sealed.from_public_key(public_key)

--- a/multi_repo.gemspec
+++ b/multi_repo.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "licensee"
   spec.add_runtime_dependency "minigit"
   spec.add_runtime_dependency "more_core_extensions"
-  spec.add_runtime_dependency "octokit", ">=4.23.0"
+  spec.add_runtime_dependency "octokit", ">= 7.0.0"
   spec.add_runtime_dependency "optimist"
   spec.add_runtime_dependency "progressbar"
   spec.add_runtime_dependency "psych", ">=3"


### PR DESCRIPTION
In newer versions of GitHub this method was renamed.  This PR bumps the minimum octokit to 7.0 which is when this renamed method was introduced.

@agrare Please review.