### PR TITLE
Allow overriding the path for a repo

### DIFF
--- a/lib/multi_repo/repo.rb
+++ b/lib/multi_repo/repo.rb
@@ -5,11 +5,11 @@ module MultiRepo
     attr_reader :name, :config, :path
     attr_accessor :dry_run
 
-    def initialize(name, config: nil, dry_run: false)
+    def initialize(name, path: nil, config: nil, dry_run: false)
       @name    = name
       @dry_run = dry_run
       @config  = OpenStruct.new(config || {})
-      @path    = MultiRepo.repos_dir.join(name)
+      @path    = path || MultiRepo.repos_dir.join(name)
     end
 
     alias to_s inspect


### PR DESCRIPTION
@agrare Please review.

This was needed on the manageiq-release side where I needed a MultiRepo::Repo object, but by that point I had already `cd`'d into the repos dir, so the repos_dir wasn't valid anymore.  Having a way to override the path solved that.