### PR TITLE
Option to force creation of the pull request without asking

### DIFF
--- a/lib/multi_repo/helpers/pull_request_blaster_outer.rb
+++ b/lib/multi_repo/helpers/pull_request_blaster_outer.rb
@@ -2,9 +2,9 @@ require 'pathname'
 
 module MultiRepo::Helpers
   class PullRequestBlasterOuter
-    attr_reader :repo, :base, :head, :script, :dry_run, :message, :title
+    attr_reader :repo, :base, :head, :script, :dry_run, :message, :title, :force
 
-    def initialize(repo, base:, head:, script:, dry_run:, message:, title: nil, **)
+    def initialize(repo, base:, head:, script:, dry_run:, message:, title: nil, force: false, **)
       @repo    = repo
       @base    = base
       @head    = head
@@ -16,6 +16,7 @@ module MultiRepo::Helpers
       @dry_run = dry_run
       @message = message
       @title   = (title || message)[0, 72]
+      @force   = force
     end
 
     def blast
@@ -43,8 +44,14 @@ module MultiRepo::Helpers
           puts "** dry-run: Skipping opening pull request".light_black
           result = "dry run".light_black
         else
-          print "Do you want to open a pull request on #{repo.name} with the above changes? (y/N): "
-          answer = $stdin.gets.chomp
+          answer =
+            if force
+              "Y"
+            else
+              print "Do you want to open a pull request on #{repo.name} with the above changes? (y/N): "
+              $stdin.gets.chomp
+            end
+
           if answer.upcase.start_with?("Y")
             fork_repo unless forked?
             push_branch

--- a/scripts/pull_request_blaster_outer
+++ b/scripts/pull_request_blaster_outer
@@ -17,6 +17,8 @@ opts = Optimist.options do
   opt :message, "The commit message for this change.",                        :type => :string, :required => true
   opt :title,   "The PR title for this change. (default is --message)",       :type => :string
 
+  opt :force,   "Force creation of the pull request without asking.", :default => false
+
   MultiRepo::CLI.common_options(self)
 end
 


### PR DESCRIPTION
In my workflow, I do a lot of dry-run runs, so by the time I run it for real I know I want to create a pull request. This option allows that workflow, but defaults to false.

@jrafanie Please review.