### PR TITLE
Pin json gem to 2.9.1 since 2.10.0+ is broken

### DIFF
--- a/multi_repo.gemspec
+++ b/multi_repo.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "colorize"
   spec.add_runtime_dependency "config"
+  spec.add_runtime_dependency "json", "~> 2.9.1" # Pin json due to https://github.com/ruby/json/issues/752
   spec.add_runtime_dependency "licensee"
   spec.add_runtime_dependency "minigit"
   spec.add_runtime_dependency "more_core_extensions"


### PR DESCRIPTION
In https://github.com/ruby/json/issues/752, we can see that due to a bug in rubygems, the wrong json extension is being loaded when used in comibination with the json_pure gem, since they share some pathing within their gems. json 2.10.0 introduced a new, rewritten, C-extension that is introducing this bug.

json_pure comes in because of travis, and I can't control the version there.

@jrafanie Please review.  I need to get this in and cut a release, so I can use multi_repo for the branching and backporting via manageiq-release.