### PR TITLE
Require active_support

### DIFF
--- a/lib/multi_repo.rb
+++ b/lib/multi_repo.rb
@@ -1,6 +1,9 @@
 require 'pathname'
 require 'pp'
 
+require 'logger'
+require 'active_support'
+
 require 'multi_repo/version'
 
 require 'multi_repo/labels'


### PR DESCRIPTION
Newer versions of active_support need the base require before any specific require. Since most modules use active_support in some way, we can just require it up front. Older versions of active_support are required on older rubies (for travis gem specifically), and so we need to require logger since there's a bug on those older active_support versions.

@jrafanie Please review. This is a follow up to that other issue where I reordered activesupport ahead of multi_repo.