### PR TITLE
[pull_request_blaster_outer] Prevent git show paging when using --force

### DIFF
--- a/lib/multi_repo/helpers/pull_request_blaster_outer.rb
+++ b/lib/multi_repo/helpers/pull_request_blaster_outer.rb
@@ -112,7 +112,11 @@ module MultiRepo::Helpers
     end
 
     def show_commit
-      repo.git.client.show
+      if force
+        repo.git.raw("--no-pager", "show")
+      else
+        repo.git.client.show
+      end
     end
 
     def blast_remote


### PR DESCRIPTION
--force is meant for avoiding any user input on each repo and allowing it to proceed to create the PR. However, when showing the diff, if git is defined to use a pager it will (and by default git uses a pager). This blocks and waits for the user to escape the pager, which kills the purpose of --force.

Unfortunately, minigit doesn't allow params to the git command (such as --no-pager), and those params go to the command instead. So, this commit introduces a raw command on the git helper which is a thin wrapper around the `git` cli. Since the code was borrowed from the clone command, this commit also changes the clone command to reuse it.

@jrafanie Please review.