### PR TITLE
Update licensee to at least 9.7.0

### DIFF
--- a/multi_repo.gemspec
+++ b/multi_repo.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "colorize"
   spec.add_runtime_dependency "config"
-  spec.add_runtime_dependency "licensee"
+  spec.add_runtime_dependency "licensee", ">= 9.7.0"
   spec.add_runtime_dependency "minigit"
   spec.add_runtime_dependency "more_core_extensions"
   spec.add_runtime_dependency "octokit", ">= 7.0.0"


### PR DESCRIPTION
Older versions of licensee don't work with newer versions of rugged, so ensure we have at least this version to avoid the error:

```
extconf.rb:101:in `block in <main>': undefined method `exists?' for class Dir
(NoMethodError)

    Dir.mkdir("build") if !Dir.exists?("build")
                              ^^^^^^^^
Did you mean?  exist?
	from extconf.rb:100:in `chdir'
	from extconf.rb:100:in `<main>'

...

An error occurred while installing rugged (0.99.0), and Bundler cannot continue.

In Gemfile:
  multi_repo was resolved to 1.0.0, which depends on
    licensee was resolved to 9.6.0, which depends on
      rugged
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
