### PR TITLE
Separate progress bar options from creation of the progress bar

### DIFF
--- a/lib/multi_repo/cli.rb
+++ b/lib/multi_repo/cli.rb
@@ -84,11 +84,15 @@ module MultiRepo
 
     def self.progress_bar(total = 100)
       require "progressbar"
-      ProgressBar.create(
+      ProgressBar.create(progress_bar_options(total))
+    end
+
+    def self.progress_bar_options(total = 100)
+      {
         :format => "%j%% |%B| %E",
         :length => HEADER_SIZE,
         :total  => total
-      )
+      }
     end
   end
 end


### PR DESCRIPTION
I recently wrote a script that used the parallel gem, which has its own internal progress bar creation, but can accept options. As such, I needed the options, but not the bar itself, which this PR allows for.

@jrafanie Please review.