### PR TITLE
Fix a constant problem

### DIFF
--- a/scripts/delete_labels
+++ b/scripts/delete_labels
@@ -13,7 +13,7 @@ opts = Optimist.options do
 
   MultiRepo::CLI.common_options(self, :repo_set_default => nil)
 end
-opts[:repo] = MultiRepo::Helpers::Labels.all.keys.sort unless opts[:repo] || opts[:repo_set]
+opts[:repo] = MultiRepo::Labels.all.keys.sort unless opts[:repo] || opts[:repo_set]
 
 github = MultiRepo::Service::Github.new(dry_run: opts[:dry_run])
 


### PR DESCRIPTION
In 34ca1e4a915258f5a210ebbc9e5b917f30536843, an UpdateLabels constant was moved
to the Helpers namespace.  From what I can see MultiRepo::Labels is not a helper
and I believe this file was changed mistakenly.

Before:

```ruby
% ./scripts/delete_labels --labels "ZZZZ"
./scripts/delete_labels:16:in `<main>': uninitialized constant MultiRepo::Helpers::Labels (NameError)

opts[:repo] = MultiRepo::Helpers::Labels.all.keys.sort unless opts[:repo] || opts[:repo_set]
                                ^^^^^^^^
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
