### PR TITLE
[each_repo] Fix each_repo when the script needs to bundle

### DIFF
--- a/scripts/each_repo
+++ b/scripts/each_repo
@@ -19,7 +19,9 @@ MultiRepo::CLI.each_repo(**opts) do |repo|
   repo.git.fetch
   repo.git.hard_checkout(opts[:ref])
   repo.chdir do
-    puts "+ #{opts[:command]}".light_black
-    system(opts[:command])
+    Bundler.with_unbundled_env do
+      puts "+ #{opts[:command]}".light_black
+      system(opts[:command])
+    end
   end
 end


### PR DESCRIPTION
If the script in question needed to do a bundle command, the multi_repo bundler got in the way.
