### PR TITLE
Handle when tags move during a git fetch which would otherwise fail

### DIFF
--- a/lib/multi_repo/service/git.rb
+++ b/lib/multi_repo/service/git.rb
@@ -49,7 +49,7 @@ module MultiRepo::Service
     def fetch(output: false)
       client = output ? self.client : self.client.capturing
 
-      client.fetch(:all => true, :tags => true)
+      client.fetch(:all => true, :tags => true, :force => true)
     end
 
     def hard_checkout(branch, source = "origin/#{branch}", output: false)


### PR DESCRIPTION
@bdunne Please review. When we move tags, this command can fail. In general, when we fetch, we expect a clean fetch and have it fix anything.